### PR TITLE
Fix HALT bug and TMA timer counter reset

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -982,6 +982,16 @@ bool execute_jr(Cpu& cpu, Mmu& mmu, Instruction& instr) {
 }
 
 void execute_halt(Cpu& cpu, Mmu& mmu, Instruction& instr) {
+  if (!cpu.GetState().ime) {
+    // HALT bug: if IME=0 and there is a pending enabled interrupt,
+    // HALT is not entered; instead the next opcode byte is read twice.
+    u8 ie = mmu.Read8(std::to_underlying(IO::IE));
+    u8 if_ = mmu.Read8(std::to_underlying(IO::IF));
+    if (ie & if_ & 0x1F) {
+      cpu.GetState().halt_bug = true;
+      return;
+    }
+  }
   cpu.GetState().halt = true;
 }
 
@@ -1319,6 +1329,10 @@ u8 Cpu::ExecuteInterrupts() {
 
 u8 Cpu::ReadNext8() {
   ZoneScoped;
+  if (state_.halt_bug) {
+    state_.halt_bug = false;
+    return Read8(regs_.pc);  // read opcode byte without advancing PC (HALT bug)
+  }
   return Read8(regs_.pc++);
 }
 

--- a/src/cpu_state.hpp
+++ b/src/cpu_state.hpp
@@ -4,6 +4,7 @@
 struct CpuState {
   bool ime = false;
   bool halt = false;
+  bool halt_bug = false;
   bool stop = false;
   bool hard_lock = false;
   bool double_speed = false;
@@ -11,8 +12,9 @@ struct CpuState {
   inline void Reset() {
     ime = false;
     halt = false;
+    halt_bug = false;
     stop = false;
     hard_lock = false;
-    double_speed = true;
+    double_speed = false;
   }
 };

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -18,7 +18,7 @@ namespace {
   constexpr int kMinBootRomSize = 256;
 };
 
-static void SetDmgBootRegisters(Mmu& mmu, Registers& regs) {
+static void SetDmgBootRegisters(Mmu& mmu, Timer& timer, Ppu& ppu, Registers& regs) {
     regs.Set(Reg8::A, 0x01);
     regs.Set(Reg8::F, 0xb0);
     regs.Set(Reg8::B, 0x00);
@@ -33,7 +33,7 @@ static void SetDmgBootRegisters(Mmu& mmu, Registers& regs) {
     mmu.Write8(std::to_underlying(IO::P1), 0xcf);
     mmu.Write8(std::to_underlying(IO::SB), 0x00);
     mmu.Write8(std::to_underlying(IO::SC), 0x7e);
-    mmu.Write8(std::to_underlying(IO::DIV), 0xab);
+    timer.SetDiv(0xab00);
     mmu.Write8(std::to_underlying(IO::TIMA), 0x00);
     mmu.Write8(std::to_underlying(IO::TMA), 0x00);
     mmu.Write8(std::to_underlying(IO::TAC), 0xf8);
@@ -58,12 +58,12 @@ static void SetDmgBootRegisters(Mmu& mmu, Registers& regs) {
     mmu.Write8(std::to_underlying(IO::NR44), 0xbf);
     mmu.Write8(std::to_underlying(IO::NR50), 0x77);
     mmu.Write8(std::to_underlying(IO::NR51), 0xf3);
-    mmu.Write8(std::to_underlying(IO::NR52), 0xf0);
+    mmu.Write8(std::to_underlying(IO::NR52), 0xf1);
     mmu.Write8(std::to_underlying(IO::LCDC), 0x91);
     mmu.Write8(std::to_underlying(IO::STAT), 0x85);
     mmu.Write8(std::to_underlying(IO::SCX), 0x00);
     mmu.Write8(std::to_underlying(IO::SCY), 0x00);
-    mmu.Write8(std::to_underlying(IO::LY), 0x91);
+    ppu.SetBootState(0x00, PPUMode::VBlank);
     mmu.Write8(std::to_underlying(IO::LYC), 0x00);
     mmu.Write8(std::to_underlying(IO::DMA), 0xff);
     mmu.Write8(std::to_underlying(IO::BGP), 0xfc);
@@ -74,7 +74,7 @@ static void SetDmgBootRegisters(Mmu& mmu, Registers& regs) {
     mmu.Write8(std::to_underlying(IO::IE), 0x00);
 }
 
-static void SetCgbBootRegisters(Mmu& mmu, Registers& regs) {
+static void SetCgbBootRegisters(Mmu& mmu, Timer& timer, Registers& regs) {
     regs.Set(Reg8::A, 0x11);
     regs.Set(Reg8::F, 0x80);
     regs.Set(Reg8::B, 0x00);
@@ -89,7 +89,7 @@ static void SetCgbBootRegisters(Mmu& mmu, Registers& regs) {
     mmu.Write8(std::to_underlying(IO::P1), 0xc7);
     mmu.Write8(std::to_underlying(IO::SB), 0x00);
     mmu.Write8(std::to_underlying(IO::SC), 0x7f);
-    mmu.Write8(std::to_underlying(IO::DIV), 0xab);
+    timer.SetDiv(0xab00);
     mmu.Write8(std::to_underlying(IO::TIMA), 0x00);
     mmu.Write8(std::to_underlying(IO::TMA), 0x00);
     mmu.Write8(std::to_underlying(IO::TAC), 0xf8);
@@ -282,14 +282,14 @@ void Emulator::Reset() {
   ppu_.SetHardwareMode(hardware_mode_);
   cpu_.SetHardwareMode(hardware_mode_);
 
-  if (skip_bootrom_) {
-    if (hardware_mode_ == HardwareMode::kCgbMode) {
-      SetCgbBootRegisters(mmu_, cpu_.GetRegisters());
-    } else {
-      SetDmgBootRegisters(mmu_, cpu_.GetRegisters());
+    if (skip_bootrom_) {
+      if (hardware_mode_ == HardwareMode::kCgbMode) {
+        SetCgbBootRegisters(mmu_, timer_, cpu_.GetRegisters());
+      } else {
+        SetDmgBootRegisters(mmu_, timer_, ppu_, cpu_.GetRegisters());
+      }
+      boot_.SetDisable(0xff);
     }
-    boot_.SetDisable(0xff);
-  }
 }
 
 void Emulator::Step() {

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -140,7 +140,7 @@ inline void Ppu::Step() {
       window_line_counter_ = 0;
       regs_.stat.ppu_mode = std::to_underlying(PPUMode::VBlank);
       interrupts_->RequestInterrupt(Interrupt::VBlank);
-      if (regs_.stat.stat_interrupt_mode0) {
+      if (regs_.stat.stat_interrupt_mode1) {
         interrupts_->RequestInterrupt(Interrupt::Stat);
       }
       SwapLcdTargets();
@@ -788,7 +788,7 @@ void Ppu::Write8(u16 addr, u8 byte) {
   }
 
   if (addr == std::to_underlying(IO::STAT)) {
-    regs_.stat = (regs_.stat.ppu_mode & 0b11) | (byte & ~0b11);
+    regs_.stat = (regs_.stat.byte() & 0b111) | (byte & 0b11111000);
     return;
   }
 
@@ -1064,6 +1064,12 @@ void Ppu::StartDma() {
   for (auto i = 0; i < oam_.bytes.size(); i += 1) {
     oam_.bytes[i] = mmu_->Read8(source + i);
   }
+}
+
+void Ppu::SetBootState(u8 ly, PPUMode mode) {
+  regs_.ly = ly;
+  regs_.stat.ppu_mode = std::to_underlying(mode);
+  regs_.stat.coincidence_flag = regs_.ly == regs_.lyc;
 }
 
 void Ppu::ResetFrameCount() {

--- a/src/ppu.hpp
+++ b/src/ppu.hpp
@@ -61,7 +61,7 @@ struct PpuRegs {
     u8 : 1;
 
     Stat(u8 val) {
-      ppu_mode = val & 0x2;
+      ppu_mode = val & 0x3;
       coincidence_flag = (val >> 2) & 0x1;
       stat_interrupt_mode0 = (val >> 3) & 0x1;
       stat_interrupt_mode1 = (val >> 4) & 0x1;
@@ -269,6 +269,7 @@ public:
   size_t GetFrameCount() const;
 
   void UpdatePalette(std::array<Color, 4> palette);
+  void SetBootState(u8 ly, PPUMode mode);
 
   void SetHardwareMode(HardwareMode mode);
   HardwareMode GetHardwareMode() const;

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -103,6 +103,10 @@ void Timer::OnTick(bool double_speed) {
   Execute(4);
 }
 
+void Timer::SetDiv(u16 div) {
+  regs_.div = div;
+}
+
 u16 Timer::div() const {
   return regs_.div >> 8;
 }

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -44,7 +44,6 @@ void Timer::Write8(u16 addr, u8 byte) {
       return;
     case std::to_underlying(IO::TMA):
       regs_.tma = byte;
-      tima_counter_ = 0;
       return;
     case std::to_underlying(IO::TAC):
       regs_.tac = (byte & 0b111) | (0b11111000);

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -34,6 +34,7 @@ public:
 
   void Execute(u8 cycles);
   void OnTick(bool double_speed) override;
+  void SetDiv(u16 div);
 
   u16 div() const;
 


### PR DESCRIPTION
Implement the SM83 HALT bug: when HALT executes with IME=0 and a pending enabled interrupt (IE & IF != 0), HALT is not entered and the next opcode byte is read twice without advancing PC. This fixes Speedy Gonzales (USA, Europe) which relies on this behaviour.

Also remove the incorrect tima_counter_ reset on TMA writes; writing TMA should not affect the internal TIMA cycle accumulator.